### PR TITLE
Changed NSFW to NSFQ; red to sickly green

### DIFF
--- a/components/Admin/KickStreamButton.vue
+++ b/components/Admin/KickStreamButton.vue
@@ -52,7 +52,7 @@
         <v-divider />
 
         <v-card-actions>
-          <span>NSFW:</span>
+          <span>NSFQ:</span>
           <v-spacer />
           <v-btn
             color="blue"

--- a/components/EditStreamData.vue
+++ b/components/EditStreamData.vue
@@ -60,7 +60,7 @@
                 v-if="!previewData"
                 v-model="streamData.nsfw"
                 class="my-0"
-                label="NSFW (Not Safe For Work)"
+                label="NSFQ (Not Safe For Quarantine)"
                 color="primary"
                 hide-details
                 inset
@@ -71,9 +71,9 @@
 
                 <template #label>
                   <div>
-                    NSFW <span class="caption">(Not Safe For Work)</span>
+                    NSFQ <span class="caption">(Not Safe For Quarantine)</span>
                     <v-btn
-                      title="More info about NSFW setting"
+                      title="More info about NSFQ setting"
                       class="ml-2"
                       icon
                       x-small
@@ -94,7 +94,7 @@
                   class="mr-2"
                   small
                   outlined
-                >NSFW</v-chip>
+                >NSFQ</v-chip>
                 {{ this.streamData.title }}
               </div>
             </v-scroll-y-transition>
@@ -110,7 +110,7 @@
             </v-btn>
           </div>
 
-          <!-- NSFW note -->
+          <!-- NSFQ note -->
           <v-expand-transition>
             <div v-show="showNSFWNote" class="mb-4 px-3">
               <v-alert
@@ -122,8 +122,8 @@
                 <div class="caption">
                   <span class="font-weight-bold">Note:</span> This setting <strong>can</strong> be safely modified mid-stream as needed.<br>
                   Changes to this setting will apply immediately upon saving.<br>
-                  Additionally, NSFW streams will appear in <strong>red</strong> on sidebar, and have their thumbnail blurred on the homepage.<br>
-                  NSFW streams are additionally prohibited from being selected as the homepage autoplay stream.
+                  Additionally, NSFQ streams will appear in <strong>red</strong> on sidebar, and have their thumbnail blurred on the homepage.<br>
+                  NSFQ streams are additionally prohibited from being selected as the homepage autoplay stream.
                 </div>
 
                 <template #close>

--- a/components/Replay/ReplayCard.vue
+++ b/components/Replay/ReplayCard.vue
@@ -102,7 +102,7 @@
           <template v-if="nsfw">
             <v-divider vertical class="mx-2"/>
             <div class="d-flex align-center">
-              <div class="red--text font-weight-bold">NSFW</div>
+              <div class="red--text font-weight-bold">NSFQ</div>
             </div>
           </template>
 

--- a/components/StreamCard.vue
+++ b/components/StreamCard.vue
@@ -48,7 +48,7 @@
           <template v-if="nsfw">
             <v-divider vertical class="mx-2"/>
             <div class="d-flex align-center">
-              <div class="red--text font-weight-bold">NSFW</div>
+              <div class="green--text font-weight-bold">NSFQ</div>
             </div>
           </template>
 

--- a/components/SubLayout/sidebar/StreamerList.vue
+++ b/components/SubLayout/sidebar/StreamerList.vue
@@ -25,7 +25,7 @@
           exact
           @click="onClick"
           no-prefetch
-          :title="`${user.nsfw ? '(NSFW) ' : ''}${user.name}`"
+          :title="`${user.nsfw ? '(NSFQ) ' : ''}${user.name}`"
         >
           <v-list-item-avatar
             :color="user.live ? user.nsfw ? '#ff4b66' : '#13a9fe' : '#000'"

--- a/pages/_watch/index.vue
+++ b/pages/_watch/index.vue
@@ -24,7 +24,7 @@
         </div>
         <div class="d-flex align-center">
           <template v-if="nsfw">
-            <div class="font-weight-bold red--text body-2">NSFW</div>
+            <div class="font-weight-bold green--text body-2">NSFQ</div>
             <v-divider vertical class="mx-2"/>
           </template>
           <KickStreamButton

--- a/pages/_watch/replay/_replay.vue
+++ b/pages/_watch/replay/_replay.vue
@@ -24,7 +24,7 @@
         </div>
         <div class="d-flex align-center">
           <template v-if="nsfw">
-            <div class="font-weight-bold red--text body-2">NSFW</div>
+            <div class="font-weight-bold green--text body-2">NSFQ</div>
             <v-divider vertical class="mx-2"/>
           </template>
           <KickStreamButton

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,7 +32,7 @@
             <div class="headline font-weight-light grey--text">Live Now</div>
             <v-switch
               v-model="blurNSFW"
-              label="Blur NSFW thumbnails"
+              label="Blur NSFQ thumbnails"
               color="primary"
               hide-details
               dense
@@ -58,7 +58,7 @@
             <div class="headline font-weight-light grey--text">Trending Replays</div>
             <v-switch
               v-model="blurNSFW"
-              label="Blur NSFW thumbnails"
+              label="Blur NSFQ thumbnails"
               color="primary"
               hide-details
               dense
@@ -84,7 +84,7 @@
             <div class="headline font-weight-light grey--text">Recent Replays</div>
             <v-switch
               v-model="blurNSFW"
-              label="Blur NSFW thumbnails"
+              label="Blur NSFQ thumbnails"
               color="primary"
               hide-details
               dense

--- a/pages/replays.vue
+++ b/pages/replays.vue
@@ -10,7 +10,7 @@
           <v-spacer />
           <v-switch
             v-model="blurNSFW"
-            label="Blur NSFW thumbnails"
+            label="Blur NSFQ thumbnails"
             color="primary"
             hide-details
             dense


### PR DESCRIPTION
This would close #122, only 50 days late.

I don't know the first thing about JS frameworks, but shouldn't this have been in a neat localisation file? 

Either way, there's still possibly one NSFW left, in `pages/profile.vue:177` (in a `<v-switch>` component, attribute `label`), which I'm not sure if it's a Vue thing or an actual label text the user will see.