### PR TITLE
Added drag-n-drop for emotes

### DIFF
--- a/components/Chat/ChatInput.vue
+++ b/components/Chat/ChatInput.vue
@@ -25,7 +25,6 @@
         dense
         clearable
         counter="300"
-        @focus="onFocus"
         @change="value => this.setChatMessage( value )"
         @keyup.delete="updateMessage"
         @keyup.enter.prevent="sendMessage"
@@ -356,11 +355,6 @@
           this.acSize = 5;
           return emoteMatch;
         }
-      },
-
-      // Defer some load events til user interacts with chat
-      async onFocus () {
-        await this.updateEmoteList();
       },
 
       updateEmoteList() {


### PR DESCRIPTION
The store's `updateEmoteList()` has been renamed into `updateEmoteListInStore()`, and a function `updateEmoteList()` is there to replace it.

Since `store.emoteList` is an array, searching for matching links would be inefficient. Thus, `updateEmoteList()` makes sure that there is an updated link-emote map. It's only called from one spot, once, but it's written so that it can be haphazardly called from anywhere (and still work).