### PR TITLE
Add support for discord webhooks

### DIFF
--- a/components/profile/ManageWebhooks.vue
+++ b/components/profile/ManageWebhooks.vue
@@ -1,0 +1,118 @@
+<template>
+  <div>
+    <div
+      v-if="!webhooks || webhooks.length === 0"
+      class="mb-3"
+    >
+      No webhooks have been created!
+    </div>
+    <div
+      v-for="webhook in webhooks"
+      class="d-flex align-center mb-3"
+    >
+      <v-text-field
+        class="mr-2"
+        solo-inverted
+        hide-details
+        :value="webhook.data.webhook"
+        readonly
+      />
+      <v-btn
+        color="red"
+        @click="deleteWebhook( webhook.id )"
+      ><v-icon>delete</v-icon></v-btn>
+    </div>
+
+    <div>
+      <v-text-field
+        placeholder="Discord Webhook URL"
+        class="mb-3"
+        solo-inverted
+        hide-details
+        v-model="newWebhook"
+      />
+      <v-btn
+        :loading="loading"
+        color="primary"
+        @click="createOnLiveWebhook"
+      >Add Webhook</v-btn>
+    </div>
+  </div>
+</template>
+
+<script>
+  import { db } from '@/plugins/firebase';
+  import { mapGetters } from 'vuex';
+  import { VStore } from '@/store';
+
+  export default {
+    name: 'ManageWebhooks',
+
+    data() {
+      return {
+        webhooks: [],
+        newWebhook: '',
+        loading: false,
+      };
+    },
+
+    methods: {
+      async getWebhooks () {
+        const result = await db
+          .collection('webhooks')
+          .where( 'owner', '==', this.uid )
+          .limit( 10 )
+          .get();
+
+        if ( result.empty ) {
+          this.webhooks = [];
+          return;
+        }
+
+        this.webhooks = result.docs.map( doc => {
+          const data = doc.data();
+          const id = doc.id;
+          return {
+            id: id,
+            data: data,
+          }
+        });
+      },
+
+      async createOnLiveWebhook () {
+        this.loading = true;
+        await this.createWebhook( this.newWebhook, 'stream-start' );
+        this.newWebhook = '';
+        await this.getWebhooks();
+        this.loading = false;
+      },
+
+      async createWebhook ( webhook, event ) {
+        await db
+          .collection('webhooks')
+          .add({
+            _username: this.username.toLowerCase(),
+            event: event,
+            owner: this.uid,
+            webhook: webhook,
+          });
+      },
+
+      async deleteWebhook ( id ) {
+        await db.collection( 'webhooks' ).doc( id ).delete();
+        await this.getWebhooks();
+      },
+    },
+
+    computed: {
+      ...mapGetters({
+        uid: VStore.$getters.getUID,
+        username : VStore.$getters.getUsername,
+      }),
+    },
+
+    async mounted() {
+      await this.getWebhooks();
+    },
+  };
+</script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwave.tv",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "An open platform live streaming service for creators to freely express themselves.",
   "author": "Dispatch",
   "scripts": {

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -231,6 +231,26 @@
       </v-flex>
     </v-layout>
 
+    <!-- Webhooks -->
+    <v-layout justify-center>
+      <v-flex
+        v-if="showStreamInfo"
+        xs12
+        sm10
+        md8
+        lg6
+      >
+        <v-card class="mb-4 pa-3">
+          <v-flex class="mb-3">
+            <h2>Discord Webhooks</h2>
+          </v-flex>
+          <div>
+            <manage-webhooks />
+          </div>
+        </v-card>
+      </v-flex>
+    </v-layout>
+
   </v-container>
 </template>
 
@@ -241,12 +261,14 @@
   import { VStore } from '@/store';
 
   import AccountDetails from '@/components/profile/AccountDetails';
+  import ManageWebhooks from '@/components/profile/ManageWebhooks';
 
   export default {
 
     name: 'profile',
 
     components: {
+      ManageWebhooks,
       AccountDetails,
     },
 


### PR DESCRIPTION
Basic UI elements for adding discord webhooks to bitwave for live notifications on discord.

Live notifications are rate limited to once every 6 hours currently to prevent spamming discord notifications.

![image](https://user-images.githubusercontent.com/45262335/84572587-d2dde300-ad4f-11ea-950f-a001315c6005.png)
