### PR TITLE
Chat settings redesign

### DIFF
--- a/components/Chat/ChatMessages/ChatMessageMenu.vue
+++ b/components/Chat/ChatMessages/ChatMessageMenu.vue
@@ -107,7 +107,7 @@
               class="mr-2"
               small
               @click="banUser"
-            >Ban</v-btn>
+            >Mute</v-btn>
             <v-btn
               color="error"
               class="mr-2"

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatBetaSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatBetaSettingsPanel.vue
@@ -2,7 +2,7 @@
   <v-card
     flat
     tile
-    class="pb-3 px-3"
+    class="mb-3 mx-3"
   >
     <!-- Beta Settings Toggles -->
     <div>

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatBetaSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatBetaSettingsPanel.vue
@@ -1,0 +1,82 @@
+<template>
+  <v-card
+    flat
+    tile
+    class="pb-3 px-3"
+  >
+    <!-- Beta Settings Subheader -->
+    <v-subheader class="overline mb-0">
+      Experimental Options <sup class="red--text ml-2">BETA</sup>
+    </v-subheader>
+
+    <!-- Beta Settings Toggles -->
+    <div>
+      <v-switch
+        v-model="trackMetrics"
+        label="Keep track of chat statistics"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+
+      <v-switch
+        v-model="trackMetricsPerUser"
+        :disabled="!trackMetrics"
+        label="Track stats per-user"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+    </div>
+  </v-card>
+</template>
+
+<script>
+  import { mapMutations, mapState } from 'vuex';
+  import { Chat } from '@/store/chat';
+
+  export default {
+    name: 'ChatBetaSettingsPanel',
+
+    data() {
+      return {};
+    },
+
+    methods: {
+      ...mapMutations (Chat.namespace, {
+        setTrackMetrics        : Chat.$mutations.setTrackMetrics,
+        setTrackMetricsPerUser : Chat.$mutations.setTrackMetricsPerUser,
+      }),
+
+      updateSettings() {
+        const settings = {};
+        this.$emit( 'input', settings );
+      },
+    },
+
+    computed: {
+      ...mapState (Chat.namespace, {
+        getTrackMetrics        : Chat.$states.trackMetrics,
+        getTrackMetricsPerUser : Chat.$states.trackMetricsPerUser,
+      }),
+
+      trackMetrics: {
+        set ( val ) {
+          this.setTrackMetrics( val );
+          this.$analytics.logEvent( 'chat_track_metrics', { value: val } );
+        },
+        get () { return this.getTrackMetrics }
+      },
+
+      trackMetricsPerUser: {
+        set ( val ) {
+          this.setTrackMetricsPerUser( val );
+          this.$analytics.logEvent( 'chat_track_metrics_per_user', { value: val } );
+        },
+        get () { return this.getTrackMetricsPerUser }
+      },
+    },
+  };
+</script>

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatBetaSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatBetaSettingsPanel.vue
@@ -4,11 +4,6 @@
     tile
     class="pb-3 px-3"
   >
-    <!-- Beta Settings Subheader -->
-    <v-subheader class="overline mb-0">
-      Experimental Options <sup class="red--text ml-2">BETA</sup>
-    </v-subheader>
-
     <!-- Beta Settings Toggles -->
     <div>
       <v-switch

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatGeneralSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatGeneralSettingsPanel.vue
@@ -1,0 +1,180 @@
+<template>
+  <v-card
+    flat
+    tile
+    class="pb-3 px-3"
+  >
+    <!-- General Settings Toggles -->
+    <div>
+
+      <!-- Global Chat -->
+      <v-switch
+        v-model="globalChat"
+        label="Global Chat"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+
+      <!-- Receive @'s in Local -->
+      <v-switch
+        v-model="receiveMentionsInLocal"
+        :disabled="globalChat"
+        label="Recieve @'s while in local"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+
+      <!-- Ignore -->
+      <v-switch
+        v-model="useIgnore"
+        label="Ignore Users"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+
+      <!-- Notification Sounds -->
+      <v-switch
+        v-model="notificationSound"
+        label="Notification Sounds"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+
+      <!-- Autocomplete -->
+      <v-switch
+        v-model="autocomplete"
+        label="Autocomplete"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+
+      <!-- Show Timestamps -->
+      <v-switch
+        v-model="showTimestamps"
+        label="Show Timestamps"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+
+      <!-- Dense Chat -->
+      <v-switch
+        v-model="denseChat"
+        label="Higher Density Chat"
+        color="primary"
+        hide-details
+        dense
+        inset
+      />
+    </div>
+  </v-card>
+</template>
+
+<script>
+  import { mapMutations, mapState } from 'vuex';
+  import { Chat } from '@/store/chat';
+
+  export default {
+    name: 'ChatGeneralSettingsPanel',
+
+    data() {
+      return {};
+    },
+
+    methods: {
+      ...mapMutations (Chat.namespace, {
+        setModeGlobal     : Chat.$mutations.setGlobal,
+        setModeTimestamps : Chat.$mutations.setTimestamps,
+        setUseIgnore      : Chat.$mutations.setUseIgnore,
+        setNotify         : Chat.$mutations.setNotify,
+        setAutocomplete   : Chat.$mutations.setAutocomplete,
+        setHighDensity    : Chat.$mutations.setHighDensity,
+        setReceiveMentionsInLocal : Chat.$mutations.setReceiveMentionsInLocal,
+      }),
+
+      updateSettings() {
+        const settings = {};
+        this.$emit( 'input', settings );
+      },
+    },
+
+    computed: {
+      ...mapState (Chat.namespace, {
+        getModeGlobal     : Chat.$states.global,
+        getModeTimestamps : Chat.$states.timestamps,
+        getUseIgnore      : Chat.$states.useIgnore,
+        getNotify         : Chat.$states.notify,
+        getAutocomplete   : Chat.$states.autocomplete,
+        getHighDensity    : Chat.$states.highDensity,
+        getReceiveMentionsInLocal : Chat.$states.receiveMentionsInLocal,
+      }),
+
+      globalChat: {
+        set ( val ) {
+          this.setModeGlobal( val );
+          this.$analytics.logEvent( 'global_chat', { value: val } );
+        },
+        get () { return this.getModeGlobal }
+      },
+
+      showTimestamps: {
+        set ( val ) {
+          this.setModeTimestamps( val );
+          this.$analytics.logEvent( 'show_timestamps', { value: val } );
+        },
+        get () { return this.getModeTimestamps }
+      },
+
+      useIgnore: {
+        set ( val ) {
+          this.setUseIgnore( val );
+          this.$analytics.logEvent( 'use_ignore', { value: val } );
+        },
+        get () { return this.getUseIgnore }
+      },
+
+      notificationSound: {
+        set ( val ) {
+          this.setNotify( val );
+          this.$analytics.logEvent( 'chat_notifications', { value: val } );
+        },
+        get () { return this.getNotify }
+      },
+
+      autocomplete: {
+        set ( val ) {
+          this.setAutocomplete( val );
+          this.$analytics.logEvent( 'chat_autocomplete', { value: val } );
+        },
+        get () { return this.getAutocomplete }
+      },
+
+      denseChat: {
+        set ( val ) {
+          this.setHighDensity( val );
+          this.$analytics.logEvent( 'chat_high_density', { value: val } );
+        },
+        get () { return this.getHighDensity }
+      },
+
+      receiveMentionsInLocal: {
+        set ( val ) {
+          this.setReceiveMentionsInLocal( val );
+          this.$analytics.logEvent( 'chat_recieve_mentions_in_local', { value: val } );
+        },
+        get () { return this.getReceiveMentionsInLocal }
+      },
+    },
+  };
+</script>

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatGeneralSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatGeneralSettingsPanel.vue
@@ -2,7 +2,7 @@
   <v-card
     flat
     tile
-    class="pb-3 px-3"
+    class="mb-3 px-3"
   >
     <!-- General Settings Toggles -->
     <div>
@@ -21,7 +21,7 @@
       <v-switch
         v-model="receiveMentionsInLocal"
         :disabled="globalChat"
-        label="Recieve @'s while in local"
+        label="Recieve @'s in local"
         color="primary"
         hide-details
         dense

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatGeneralSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatGeneralSettingsPanel.vue
@@ -21,7 +21,7 @@
       <v-switch
         v-model="receiveMentionsInLocal"
         :disabled="globalChat"
-        label="Recieve @'s in local"
+        label="Receive @'s in local"
         color="primary"
         hide-details
         dense

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatTtsSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatTtsSettingsPanel.vue
@@ -1,0 +1,255 @@
+<template>
+  <v-card
+    flat
+    tile
+    class="pb-3 px-3"
+  >
+    <!-- TTS Settings -->
+    <div>
+      <!-- No TTS Voice Warning -->
+      <v-alert
+        v-if="!ttsVoicesExist"
+        class="my-3"
+        type="warning"
+        text
+      >
+        No TTS voices found!
+      </v-alert>
+
+      <!-- TTS Voice Options -->
+      <div
+        v-if="ttsVoicesExist"
+      >
+        <!-- Enable TTS -->
+        <v-switch
+          v-model="useTts"
+          :disabled="!ttsVoicesExist"
+          label="Enable Chat TTS"
+          color="primary"
+          hide-details
+          dense
+          inset
+        />
+
+        <!-- Troll TTS -->
+        <v-switch
+          v-model="trollTts"
+          :disabled="!useTts"
+          label="Allow Troll TTS"
+          color="primary"
+          hide-details
+          dense
+          inset
+        />
+
+        <!-- Read username -->
+        <v-switch
+          v-model="ttsReadUsername"
+          :disabled="!useTts"
+          label="Read Username"
+          color="primary"
+          hide-details
+          dense
+          inset
+          class="mb-3"
+        />
+
+        <v-divider class="mt-3" />
+
+        <!-- TTS Voice Settings Labels -->
+        <v-subheader class="overline mb-0">
+          TTS Voice Settings
+        </v-subheader>
+
+        <!-- TTS Voice -->
+        <v-select
+          v-model="ttsVoice"
+          :items="ttsVoices"
+          :disabled="!useTts"
+          label="TTS Voice"
+          style="font-size: 12px;"
+          hide-details
+          solo-inverted
+          class="mb-3"
+        />
+
+        <!-- TTS Rate -->
+        <v-slider
+          :disabled="!useTts"
+          label="Speed"
+          v-model="ttsRate"
+          class="align-center"
+          :max="20"
+          :min="1"
+          :step="0.5"
+          hide-details
+        >
+          <template #append>
+            <v-text-field
+              v-model="ttsRate"
+              class="mt-0 pt-0"
+              hide-details
+              single-line
+              type="number"
+              style="width: 50px"
+            />
+          </template>
+        </v-slider>
+
+        <!-- TTS Volume -->
+        <v-slider
+          :disabled="!useTts"
+          label="Vol."
+          v-model="ttsVolume"
+          class="align-center"
+          :max="10"
+          :min="0"
+          :step="0.5"
+          hide-details
+        />
+
+        <!-- TTS Timeout -->
+        <v-slider
+          :disabled="!useTts"
+          label="Timeout"
+          v-model="ttsTimeout"
+          class="align-center"
+          :max="60"
+          :min="0"
+          :step="0.5"
+          hide-details
+        >
+
+          <template #append>
+            <v-text-field
+              v-model="ttsTimeout"
+              class="mt-0 pt-0"
+              hide-details
+              single-line
+              type="number"
+              style="width: 50px"
+            />
+          </template>
+        </v-slider>
+
+      </div>
+    </div>
+  </v-card>
+</template>
+
+<script>
+  import { mapMutations, mapState } from 'vuex';
+  import { Chat } from '@/store/chat';
+
+  export default {
+    name: 'ChatTtsSettingsPanel',
+
+    data() {
+      return {
+        ttsVoices: [],
+      };
+    },
+
+    methods: {
+      ...mapMutations (Chat.namespace, {
+        setUseTts          : Chat.$mutations.setUseTts,
+        setTrollTts        : Chat.$mutations.setTrollTts,
+        setTtsRate         : Chat.$mutations.setTtsRate,
+        setTtsReadUsername : Chat.$mutations.setTtsReadUsername,
+        setTtsTimeout      : Chat.$mutations.setTtsTimeout,
+        setTtsVolume       : Chat.$mutations.setTtsVolume,
+        setTtsVoice        : Chat.$mutations.setTtsVoice,
+      }),
+
+      updateSettings() {
+        const settings = {};
+        this.$emit( 'input', settings );
+      },
+    },
+
+    computed: {
+      ...mapState (Chat.namespace, {
+        getUseTts          : Chat.$states.useTts,
+        getTrollTts        : Chat.$states.trollTts,
+        getTtsRate         : Chat.$states.ttsRate,
+        getTtsReadUsername : Chat.$states.ttsReadUsername,
+        getTtsTimeout      : Chat.$states.ttsTimeout,
+        getTtsVolume       : Chat.$states.ttsVolume,
+        getTtsVoice        : Chat.$states.ttsVoice,
+      }),
+
+      ttsVoicesExist: {
+        get () { return this.ttsVoices.length }
+      },
+
+      useTts: {
+        set ( val ) {
+          this.setUseTts( val );
+          this.$analytics.logEvent( 'use_tts', { value: val } );
+        },
+        get () { return this.getUseTts }
+      },
+
+      trollTts: {
+        set ( val ) {
+          this.setTrollTts( val );
+          this.$analytics.logEvent( 'allow_troll_tts', { value: val } );
+        },
+        get () { return this.getTrollTts }
+      },
+
+      ttsRate: {
+        set ( val ) {
+          this.setTtsRate( val );
+          this.$analytics.logEvent( 'tts_rate', { value: val } );
+        },
+        get () { return this.getTtsRate }
+      },
+
+      ttsReadUsername: {
+        set ( val ) {
+          this.setTtsReadUsername( val );
+          this.$analytics.logEvent( 'tts_read_username', { value: val } );
+        },
+        get () { return this.getTtsReadUsername }
+      },
+
+      ttsTimeout: {
+        set ( val ) {
+          this.setTtsTimeout( val );
+          this.$analytics.logEvent( 'tts_timeout', { value: val } );
+        },
+        get () { return this.getTtsTimeout }
+      },
+
+      ttsVolume: {
+        set ( val ) {
+          this.setTtsVolume( val );
+          this.$analytics.logEvent( 'tts_volume', { value: val } );
+        },
+        get () { return this.getTtsVolume }
+      },
+
+      ttsVoice: {
+        set ( val ) {
+          this.setTtsVoice( val );
+        },
+        get () { return this.getTtsVoice }
+      },
+    },
+
+    async mounted () {
+      // https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/onvoiceschanged
+      // This could be used to populate a list of voices that the user can choose between when the event fires
+      // Firefox doesn't support it at present, and will just return a list of voices when SpeechSynthesis.getVoices() is fired.
+      // With Chrome, you have to wait for the event to fire before populating the list, hence the bottom if statement seen below.
+
+      const getVoicesList = () => speechSynthesis.getVoices().map( ( voice, index ) => ({ text: voice.name, value: index }))
+      this.ttsVoices = getVoicesList();
+
+      if ( !speechSynthesis.onvoiceschanged ) {
+        speechSynthesis.onvoiceschanged = () => this.ttsVoices = getVoicesList();
+      }
+    },
+  };
+</script>

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatTtsSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatTtsSettingsPanel.vue
@@ -2,7 +2,7 @@
   <v-card
     flat
     tile
-    class="pb-3 mx-3"
+    class="mb-3 mx-3"
   >
     <!-- TTS Settings -->
     <div>

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatTtsSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatTtsSettingsPanel.vue
@@ -17,13 +17,10 @@
       </v-alert>
 
       <!-- TTS Voice Options -->
-      <div
-        v-if="ttsVoicesExist"
-      >
+      <template v-else>
         <!-- Enable TTS -->
         <v-switch
           v-model="useTts"
-          :disabled="!ttsVoicesExist"
           label="Enable Chat TTS"
           color="primary"
           hide-details
@@ -133,7 +130,7 @@
 
         <i class="caption grey--text">note: a value of 0 disables timeout.</i>
 
-      </div>
+      </template>
     </div>
   </v-card>
 </template>

--- a/components/Chat/ChatSettings/ChatSettingsPanel/ChatTtsSettingsPanel.vue
+++ b/components/Chat/ChatSettings/ChatSettingsPanel/ChatTtsSettingsPanel.vue
@@ -2,7 +2,7 @@
   <v-card
     flat
     tile
-    class="pb-3 px-3"
+    class="pb-3 mx-3"
   >
     <!-- TTS Settings -->
     <div>
@@ -67,10 +67,9 @@
           :items="ttsVoices"
           :disabled="!useTts"
           label="TTS Voice"
-          style="font-size: 12px;"
           hide-details
-          solo-inverted
           class="mb-3"
+          outlined
         />
 
         <!-- TTS Rate -->
@@ -131,6 +130,8 @@
             />
           </template>
         </v-slider>
+
+        <i class="caption grey--text">note: a value of 0 disables timeout.</i>
 
       </div>
     </div>

--- a/components/Chat/ChatSettings/SettingsMenu.vue
+++ b/components/Chat/ChatSettings/SettingsMenu.vue
@@ -3,49 +3,33 @@
     <v-tabs
       v-model="settingsTab"
       class="elevation-2"
+      background-color="blue-grey darken-4"
+      color="white"
+      id="chat-settings"
     >
       <!-- Tab Slider Color -->
       <v-tabs-slider />
 
       <!-- Tabs -->
       <v-tab
-        :href="`#chat-settings-general`"
+        v-for="tab in tabs"
+        :key="tab.value"
+        :href="`#${tab.value}`"
       >
-        General
-      </v-tab>
-      <v-tab
-        :href="`#chat-settings-tts`"
-      >
-        TTS
-      </v-tab>
-      <v-tab
-        :href="`#chat-settings-beta`"
-      >
-        Beta
+        {{ tab.label }}
       </v-tab>
 
       <!-- TAB: General Settings -->
       <v-tab-item
-        value="chat-settings-general"
+        v-for="tab in tabs"
+        :key="tab.value"
+        :value="tab.value"
         class="chat-settings-panel"
       >
-        <chat-general-settings-panel />
-      </v-tab-item>
-
-      <!-- TAB: TTS Settings -->
-      <v-tab-item
-        value="chat-settings-tts"
-        class="chat-settings-panel"
-      >
-        <chat-tts-settings-panel />
-      </v-tab-item>
-
-      <!-- TAB: Beta Settings -->
-      <v-tab-item
-        value="chat-settings-beta"
-        class="chat-settings-panel"
-      >
-        <chat-beta-settings-panel />
+        <component
+          :is="tab.component"
+          :key="tab.value"
+        />
       </v-tab-item>
     </v-tabs>
   </div>
@@ -64,33 +48,42 @@
       ChatGeneralSettingsPanel,
     },
 
-    props: {
-
-    },
-
     data() {
       return {
+        // Default tab
         settingsTab: 'chat-settings-general',
-      }
-    },
-
-    methods: {
-
-    },
-
-    computed: {
-
-    },
-
-    async mounted () {
-
+        tabs: [
+          {
+            label: 'General',
+            value: 'chat-settings-general',
+            component: ChatGeneralSettingsPanel,
+          },
+          {
+            label: 'TTS',
+            value: 'chat-settings-tts',
+            component: ChatTtsSettingsPanel,
+          },
+          {
+            label: 'Beta',
+            value: 'chat-settings-beta',
+            component: ChatBetaSettingsPanel,
+          },
+        ],
+      };
     },
   }
 </script>
 
 <style lang="scss">
-  .chat-settings-panel {
+  /*#chat-settings .v-window__container {
+    width: 350px;
     height: 20rem;
-    overflow: auto;
+    overflow-y: auto;
+  }*/
+
+  .chat-settings-panel {
+    width: 350px;
+    height: 20rem;
+    overflow-y: auto;
   }
 </style>

--- a/components/Chat/ChatSettings/SettingsMenu.vue
+++ b/components/Chat/ChatSettings/SettingsMenu.vue
@@ -1,260 +1,68 @@
 <template>
   <div>
-    <div class="px-3">
-      <div class="d-flex">
-        <!-- Global Chat -->
-        <v-switch
-          v-model="globalChat"
-          label="Global Chat"
-          color="primary"
-          hide-details
-          dense
-          inset
-        />
-
-        <!-- Show Timestamps -->
-        <v-switch
-          v-model="showTimestamps"
-          class="ml-3"
-          label="Timestamps"
-          color="primary"
-          hide-details
-          dense
-          inset
-        />
-      </div>
-
-      <v-switch
-        v-model="receiveMentionsInLocal"
-        :disabled="globalChat"
-        class="mb-2"
-        label="Recieve @'s while in local"
-        color="primary"
-        hide-details
-        dense
-        inset
-      />
-
-      <!-- Ignore -->
-      <v-switch
-        v-model="useIgnore"
-        label="Ignore Users"
-        class="mb-2"
-        color="primary"
-        hide-details
-        dense
-        inset
-      />
-
-      <!-- Notification Sounds -->
-      <v-switch
-        v-model="notificationSound"
-        label="Notification Sounds"
-        class="mb-2"
-        color="primary"
-        hide-details
-        dense
-        inset
-      />
-
-      <!-- Autocomplete -->
-      <v-switch
-        v-model="autocomplete"
-        label="Autocomplete"
-        class="mb-2"
-        color="primary"
-        hide-details
-        dense
-        inset
-      />
-
-      <!-- Dense Chat -->
-      <v-switch
-        v-model="denseChat"
-        label="High Density"
-        class="mb-2"
-        color="primary"
-        hide-details
-        dense
-        inset
-      />
-    </div>
-
-    <v-divider/>
-
-    <v-alert
-      v-if="!ttsVoicesExist"
-      class="mt-3 mb-3"
-      type="warning"
-      text
+    <v-tabs
+      v-model="settingsTab"
+      class="elevation-2"
     >
-      No TTS voices found!
-    </v-alert>
+      <!-- Tab Slider Color -->
+      <v-tabs-slider />
 
-    <div class="pb-2" v-if="ttsVoicesExist">
+      <!-- Tabs -->
+      <v-tab
+        :href="`#chat-settings-general`"
+      >
+        General
+      </v-tab>
+      <v-tab
+        :href="`#chat-settings-tts`"
+      >
+        TTS
+      </v-tab>
+      <v-tab
+        :href="`#chat-settings-beta`"
+      >
+        Beta
+      </v-tab>
 
-      <!-- TTS Settings -->
-      <v-subheader class="overline mb-0">Text To Speech Options</v-subheader>
+      <!-- TAB: General Settings -->
+      <v-tab-item
+        value="chat-settings-general"
+        class="chat-settings-panel"
+      >
+        <chat-general-settings-panel />
+      </v-tab-item>
 
-      <div class="px-3">
-        <div class="d-flex">
-          <!-- Enable TTS -->
-          <v-switch
-            v-model="useTts"
-            :disabled="!ttsVoicesExist"
-            label="Use TTS"
-            class="mt-0 pt-0"
-            color="primary"
-            hide-details
-            dense
-            inset
-          />
+      <!-- TAB: TTS Settings -->
+      <v-tab-item
+        value="chat-settings-tts"
+        class="chat-settings-panel"
+      >
+        <chat-tts-settings-panel />
+      </v-tab-item>
 
-          <!-- Troll TTS -->
-          <v-switch
-            v-model="trollTts"
-            :disabled="!useTts"
-            label="Troll TTS"
-            class="mt-0 ml-3 pt-0"
-            color="primary"
-            hide-details
-            dense
-            inset
-          />
-	      </div>
-
-      <!-- Read username -->
-      <v-switch
-        v-model="ttsReadUsername"
-        :disabled="!useTts"
-        label="Read Username"
-        class="mb-3 pt-0"
-        color="primary"
-        hide-details
-        dense
-        inset
-      />
-      </div>
-
-      <!-- TTS Voice -->
-      <v-flex mx-3>
-        <v-select
-          v-model="ttsVoice"
-          :items="ttsVoices"
-          :disabled="!useTts"
-          label="TTS Voice"
-          style="font-size: 12px;"
-          hide-details
-        />
-      </v-flex>
-
-      <!-- TTS Rate -->
-      <v-list-item>
-        <v-slider
-          :disabled="!useTts"
-          label="Speed"
-          v-model="ttsRate"
-          class="align-center"
-          :max="20"
-          :min="1"
-          :step="0.5"
-          hide-details
-        >
-          <template #append>
-            <v-text-field
-              v-model="ttsRate"
-              class="mt-0 pt-0"
-              hide-details
-              single-line
-              type="number"
-              style="width: 50px"
-            />
-          </template>
-        </v-slider>
-      </v-list-item>
-
-      <!-- TTS Volume -->
-      <v-list-item>
-        <v-slider
-          :disabled="!useTts"
-          label="Vol."
-          v-model="ttsVolume"
-          class="align-center"
-          :max="10"
-          :min="0"
-          :step="0.5"
-          hide-details
-        />
-      </v-list-item>
-
-      <!-- TTS Timeout -->
-      <v-list-item>
-        <v-slider
-          :disabled="!useTts"
-          label="Timeout"
-          v-model="ttsTimeout"
-          class="align-center"
-          :max="60"
-          :min="0"
-          :step="0.5"
-          hide-details
-        >
-
-          <template #append>
-            <v-text-field
-              v-model="ttsTimeout"
-              class="mt-0 pt-0"
-              hide-details
-              single-line
-              type="number"
-              style="width: 50px"
-            />
-          </template>
-        </v-slider>
-      </v-list-item>
-
-    </div>
-
-    <v-divider/>
-
-    <div class="pb-5">
-      <v-subheader class="overline mb-0">
-        Experimental Options <sup style="color: red">BETA</sup>
-      </v-subheader>
-
-      <div class="px-3">
-        <v-switch
-          v-model="trackMetrics"
-          label="Keep track of chat statistics"
-          class="mb-3 mt-0"
-          color="primary"
-          hide-details
-          dense
-          inset
-        />
-
-        <v-switch
-          v-model="trackMetricsPerUser"
-          :disabled="!trackMetrics"
-          label="Track stats per-user"
-          class="mb-0"
-          color="primary"
-          hide-details
-          dense
-          inset
-        />
-      </div>
-    </div>
-
+      <!-- TAB: Beta Settings -->
+      <v-tab-item
+        value="chat-settings-beta"
+        class="chat-settings-panel"
+      >
+        <chat-beta-settings-panel />
+      </v-tab-item>
+    </v-tabs>
   </div>
 </template>
 
 <script>
-  import { mapState, mapMutations } from 'vuex'
-  import { Chat } from '@/store/chat';
+  import ChatGeneralSettingsPanel from './ChatSettingsPanel/ChatGeneralSettingsPanel';
+  import ChatTtsSettingsPanel from './ChatSettingsPanel/ChatTtsSettingsPanel';
+  import ChatBetaSettingsPanel from './ChatSettingsPanel/ChatBetaSettingsPanel';
 
   export default {
     name: 'ChatSettings',
+    components: {
+      ChatBetaSettingsPanel,
+      ChatTtsSettingsPanel,
+      ChatGeneralSettingsPanel,
+    },
 
     props: {
 
@@ -262,194 +70,27 @@
 
     data() {
       return {
-        useIgnoreList: true,
-        ttsVoices: [],
+        settingsTab: 'chat-settings-general',
       }
     },
 
     methods: {
-      ...mapMutations (Chat.namespace, {
-        setModeGlobal     : Chat.$mutations.setGlobal,
-        setModeTimestamps : Chat.$mutations.setTimestamps,
-        setUseTts         : Chat.$mutations.setUseTts,
-        setUseIgnore      : Chat.$mutations.setUseIgnore,
-        setTrollTts       : Chat.$mutations.setTrollTts,
-        setTtsRate        : Chat.$mutations.setTtsRate,
-        setTtsReadUsername: Chat.$mutations.setTtsReadUsername,
-        setTtsTimeout     : Chat.$mutations.setTtsTimeout,
-        setTtsVolume      : Chat.$mutations.setTtsVolume,
-        setTtsVoice       : Chat.$mutations.setTtsVoice,
-        setNotify         : Chat.$mutations.setNotify,
-        setAutocomplete   : Chat.$mutations.setAutocomplete,
-        setHighDensity    : Chat.$mutations.setHighDensity,
-        setReceiveMentionsInLocal : Chat.$mutations.setReceiveMentionsInLocal,
 
-        setTrackMetrics        : Chat.$mutations.setTrackMetrics,
-        setTrackMetricsPerUser : Chat.$mutations.setTrackMetricsPerUser,
-      }),
-
-      updateSettings() {
-        const settings = {};
-        this.$emit( 'input', settings );
-      },
     },
 
     computed: {
-      ...mapState (Chat.namespace, {
-        getModeGlobal     : Chat.$states.global,
-        getModeTimestamps : Chat.$states.timestamps,
-        getUseTts         : Chat.$states.useTts,
-        getUseIgnore      : Chat.$states.useIgnore,
-        getTrollTts       : Chat.$states.trollTts,
-        getTtsRate        : Chat.$states.ttsRate,
-        getTtsReadUsername: Chat.$states.ttsReadUsername,
-        getTtsTimeout     : Chat.$states.ttsTimeout,
-        getTtsVolume      : Chat.$states.ttsVolume,
-        getTtsVoice       : Chat.$states.ttsVoice,
-        getNotify         : Chat.$states.notify,
-        getAutocomplete   : Chat.$states.autocomplete,
-        getHighDensity    : Chat.$states.highDensity,
-        getReceiveMentionsInLocal : Chat.$states.receiveMentionsInLocal,
 
-        getTrackMetrics        : Chat.$states.trackMetrics,
-        getTrackMetricsPerUser : Chat.$states.trackMetricsPerUser,
-      }),
-
-      ttsVoicesExist: {
-        get () { return this.ttsVoices.length }
-      },
-
-      globalChat: {
-        set ( val ) {
-          this.setModeGlobal( val );
-          this.$analytics.logEvent( 'global_chat', { value: val } );
-        },
-        get () { return this.getModeGlobal }
-      },
-
-      showTimestamps: {
-        set ( val ) {
-          this.setModeTimestamps( val );
-          this.$analytics.logEvent( 'show_timestamps', { value: val } );
-        },
-        get () { return this.getModeTimestamps }
-      },
-
-      useTts: {
-        set ( val ) {
-          this.setUseTts( val );
-          this.$analytics.logEvent( 'use_tts', { value: val } );
-        },
-        get () { return this.getUseTts }
-      },
-
-      useIgnore: {
-        set ( val ) {
-          this.setUseIgnore( val );
-          this.$analytics.logEvent( 'use_ignore', { value: val } );
-        },
-        get () { return this.getUseIgnore }
-      },
-
-      trollTts: {
-        set ( val ) {
-          this.setTrollTts( val );
-          this.$analytics.logEvent( 'allow_troll_tts', { value: val } );
-        },
-        get () { return this.getTrollTts }
-      },
-
-      ttsRate: {
-        set ( val ) {
-          this.setTtsRate( val );
-          this.$analytics.logEvent( 'tts_rate', { value: val } );
-        },
-        get () { return this.getTtsRate }
-      },
-
-      ttsReadUsername: {
-        set ( val ) {
-          this.setTtsReadUsername( val );
-          this.$analytics.logEvent( 'tts_read_username', { value: val } );
-        },
-        get () { return this.getTtsReadUsername }
-      },
-
-      ttsTimeout: {
-        set ( val ) {
-          this.setTtsTimeout( val );
-          this.$analytics.logEvent( 'tts_timeout', { value: val } );
-        },
-        get () { return this.getTtsTimeout }
-      },
-
-      ttsVolume: {
-        set ( val ) {
-          this.setTtsVolume( val );
-          this.$analytics.logEvent( 'tts_volume', { value: val } );
-        },
-        get () { return this.getTtsVolume }
-      },
-
-      ttsVoice: {
-        set ( val ) {
-          this.setTtsVoice( val );
-        },
-        get () { return this.getTtsVoice }
-      },
-
-      notificationSound: {
-        set ( val ) {
-          this.setNotify( val );
-          this.$analytics.logEvent( 'chat_notifications', { value: val } );
-        },
-        get () { return this.getNotify }
-      },
-
-      autocomplete: {
-        set ( val ) {
-          this.setAutocomplete( val );
-          this.$analytics.logEvent( 'chat_autocomplete', { value: val } );
-        },
-        get () { return this.getAutocomplete }
-      },
-
-      denseChat: {
-        set ( val ) {
-          this.setHighDensity( val );
-          this.$analytics.logEvent( 'chat_high_density', { value: val } );
-        },
-        get () { return this.getHighDensity }
-      },
-
-      receiveMentionsInLocal: {
-        set ( val ) {
-          this.setReceiveMentionsInLocal( val );
-          this.$analytics.logEvent( 'chat_recieve_mentions_in_local', { value: val } );
-        },
-        get () { return this.getReceiveMentionsInLocal }
-      },
-
-      trackMetrics: {
-        set ( val ) {
-          this.setTrackMetrics( val );
-          this.$analytics.logEvent( 'chat_track_metrics', { value: val } );
-        },
-        get () { return this.getTrackMetrics }
-      },
-
-      trackMetricsPerUser: {
-        set ( val ) {
-          this.setTrackMetricsPerUser( val );
-          this.$analytics.logEvent( 'chat_track_metrics_per_user', { value: val } );
-        },
-        get () { return this.getTrackMetricsPerUser }
-      },
     },
 
     async mounted () {
-      this.ttsVoices = speechSynthesis.getVoices().map( ( voice, index ) => ({ text: voice.name, value: index }));
-      speechSynthesis.onvoiceschanged = () => this.ttsVoices = speechSynthesis.getVoices().map( ( voice, index ) => ({ text: voice.name, value: index }) );
+
     },
   }
 </script>
+
+<style lang="scss">
+  .chat-settings-panel {
+    height: 20rem;
+    overflow: auto;
+  }
+</style>

--- a/components/Chat/ChatSettings/index.vue
+++ b/components/Chat/ChatSettings/index.vue
@@ -8,7 +8,6 @@
     top
     right
     offset-y
-    eager
     origin="bottom left"
     ref="chatSettingsMenu"
   >

--- a/components/Chat/ChatSettings/index.vue
+++ b/components/Chat/ChatSettings/index.vue
@@ -3,11 +3,14 @@
     v-model="showChatSettings"
     :close-on-content-click="false"
     transition="slide-x-transition"
-    :max-width="320"
+    :max-width="350"
     max-height="90vh"
     top
     right
     offset-y
+    eager
+    origin="bottom left"
+    ref="chatSettingsMenu"
   >
     <template #activator="{ on: menu }">
       <v-tooltip top :open-delay="500">
@@ -20,26 +23,36 @@
       </v-tooltip>
     </template>
 
-    <v-card class="mb-0" color="grey darken-4">
-      <!-- Title Bar -->
-      <v-sheet
-        tile
-        color="primary"
-        class="d-flex align-center justify-space-between pl-2"
+    <div class="mb-3">
+      <v-card
+        color="grey darken-4"
       >
-        <h5 class="black--text body-2">Chat Settings</h5>
-        <v-btn
-          color="black"
-          text
-          icon
-          pa-0
-          @click="close"
+        <!-- Title Bar -->
+        <v-sheet
+          tile
+          color="primary"
+          class="d-flex align-center justify-space-between pl-2"
         >
-          <v-icon color="black">close</v-icon>
-        </v-btn>
-      </v-sheet>
-      <settings-menu />
-    </v-card>
+          <h5 class="black--text body-2 font-weight-medium">
+            Chat Settings
+          </h5>
+          <v-btn
+            color="black"
+            text
+            icon
+            pa-0
+            @click="close"
+          >
+            <v-icon color="black">close</v-icon>
+          </v-btn>
+        </v-sheet>
+
+        <!-- Tabbed Settings -->
+        <settings-menu @change="onTabChange" />
+
+      </v-card>
+    </div>
+
   </v-menu>
 </template>
 
@@ -63,6 +76,10 @@
       close () {
         this.showChatSettings = false;
       },
+
+      onTabChange () {
+        this.$nextTick( () => this.$refs.chatSettingsMenu.onResize() );
+      }
     },
   };
 </script>


### PR DESCRIPTION
Creates a categorized, tabbed version of chat settings to accommodate more settings.
Separates large single settings file into 3 smaller sub components, one for each settings panel.
Settings overflow within the card, rather than entire card.

Changes TTS voice selection box to solo variant.
Moves all toggles to be in line.
Increase menu title bar font weight to bold.

Current Design:
![image](https://user-images.githubusercontent.com/45262335/86236389-d85c6b00-bb4e-11ea-86f6-a102e907942f.png)
![image](https://user-images.githubusercontent.com/45262335/86236432-e6aa8700-bb4e-11ea-95b4-ce5ff8ebec46.png)
![image](https://user-images.githubusercontent.com/45262335/86236447-ef9b5880-bb4e-11ea-8bdc-385e9923a941.png)

