### PR TITLE
Refactor token updates

### DIFF
--- a/assets/js/Cookies/parse.js
+++ b/assets/js/Cookies/parse.js
@@ -1,0 +1,7 @@
+/**
+ * Takes in an array object of containing all cookie, name-value pairs
+ *  and returns a token, or null, on bad parse.
+ */
+export const parseCookiesForAuth = ( cookies ) => {
+  return cookies?.auth ?? null;
+};

--- a/components/Admin/AdminChannelButton/AdminCreateBanner.vue
+++ b/components/Admin/AdminChannelButton/AdminCreateBanner.vue
@@ -86,14 +86,7 @@
     },
 
     methods: {
-      async updateToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async createSystemAlert () {
-        await this.updateToken();
-
         const payload = {
           message: this.systemAlertMessage,
         };

--- a/components/Admin/AdminChannelButton/AdminCreateFireworks.vue
+++ b/components/Admin/AdminChannelButton/AdminCreateFireworks.vue
@@ -93,14 +93,7 @@
     },
 
     methods: {
-      async updateToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async createFireworks () {
-        await this.updateToken();
-
         const payload = {
           message: this.FireworksMessage,
           subtext: this.FireworksSubtext,

--- a/components/Admin/AdminChannelButton/AdminStreamControl.vue
+++ b/components/Admin/AdminChannelButton/AdminStreamControl.vue
@@ -170,13 +170,6 @@
     },
 
     methods: {
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-        console.log( `Fresh ID token:`, { token } );
-        return token;
-      },
-
       async setNSFW ( nsfw ) {
         try {
           const endpoint = nsfwEndpoint + this.streamer;
@@ -189,15 +182,13 @@
         } catch ( error ) {
           console.error( error );
           this.error( error.message );
-          await this.getFreshIdToken();
         }
       },
 
       async kickStreamer ( resetKey ) {
         try {
-          const token = await this.getFreshIdToken();
           const { data } = await this.$axios.post(
-            this.createEndpoint( endpoint, token, !!resetKey ),
+            this.createEndpoint( endpoint, !!resetKey ),
             { streamer: this.streamer },
           );
           console.log( data );
@@ -218,7 +209,6 @@
 
       async transcodeStreamer ( mode, options ) {
         try {
-          await this.getFreshIdToken();
           const { data } = await this.$axios.post(
             transcodeEndpoint + mode,
             { user: this.streamer, ...options },
@@ -244,7 +234,7 @@
         this.$toast.error( error, { icon: 'error', duration: 5000, position: 'top-center' } );
       },
 
-      createEndpoint ( base, token, reset ) {
+      createEndpoint ( base, reset ) {
         return `${base}?reset=${!!reset}`;
       },
 

--- a/components/Admin/ArchiveManager.vue
+++ b/components/Admin/ArchiveManager.vue
@@ -129,11 +129,6 @@
     },
 
     methods: {
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async getArchives () {
         this.loading = true;
         const { data } = await this.$axios.get('https://api.bitwave.tv/v1/archives/old');
@@ -150,9 +145,6 @@
       },
 
       async deleteArchive ( archive ) {
-        // Refresh auth token
-        await this.getFreshIdToken();
-
         const endpoint = `https://api.bitwave.tv/v1/replays/${archive.id}`;
         const options = {
           data: {
@@ -167,7 +159,6 @@
           else this.$toast.success( data.message, { duration: 2500, icon: 'error', position: 'bottom-center' } );
           this.archives = this.archives.filter( a => a.id !== archive.id );
         } catch ( error ) {
-          await this.getFreshIdToken();
           console.log( error );
           this.$toast.error( error.message, { duration: 2500, icon: 'error', position: 'bottom-center' } );
         }

--- a/components/Admin/UpdateTrending.vue
+++ b/components/Admin/UpdateTrending.vue
@@ -30,14 +30,7 @@
     },
 
     methods: {
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async updateTrending () {
-        await this.getFreshIdToken();
-
         this.updating = true;
 
         const endpoint = `https://api.bitwave.tv/v1/replays/update-trending`;

--- a/components/Channel/EditStreamData.vue
+++ b/components/Channel/EditStreamData.vue
@@ -431,11 +431,6 @@
     },
 
     methods: {
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async getStreamData () {
         const stream = this.username.toLowerCase();
         try {
@@ -511,7 +506,6 @@
 
         // Trigger Start / Stop Archiving
         if ( this.live && this.archive !== this.streamData.archive ) {
-          await this.getFreshIdToken();
           const endpoint = `https://api.bitwave.tv/v1/streamer/recorder/${this.streamData.archive ? 'start' : 'stop' }`;
           const payload = { user: this.username.toLowerCase(), };
           try {
@@ -568,7 +562,6 @@
 
       /* Upload Cover Image */
       async uploadFile () {
-        await this.updateToken();
         if ( !this.imageFile ) return false;
         this.uploadingAvatar = true;
         const formData = new FormData();
@@ -624,13 +617,6 @@
           this.$toast.error( `Failed to delete old cover image: ${error.response.data}`, { icon: 'error', duration: 5000 } );
         }
         this.oldCoverImage = this.streamData.cover;
-      },
-
-      // In case our token expires
-      async updateToken () {
-        if ( !auth.currentUser ) return;
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
       },
     },
 

--- a/components/Channel/NotificationBell.vue
+++ b/components/Channel/NotificationBell.vue
@@ -113,11 +113,6 @@
     },
 
     methods: {
-      async updateToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       confirm ( confirm ) {
         this.showConfirmNotifications = false;
         this.confirmNotifications( confirm );
@@ -142,8 +137,6 @@
       },
 
       async togglePushNotifications () {
-        await this.updateToken();
-
         const followerDoc = await db
           .collection( 'followers' )
           .doc( `${this.user.uid}_${this.streamerId}` )

--- a/components/Channel/StreamArchives.vue
+++ b/components/Channel/StreamArchives.vue
@@ -379,8 +379,6 @@
       async deleteArchive ( archive ) {
         if ( this.processing ) return;
 
-        await this.updateToken();
-
         this.processing = true;
         archive.loading = true;
         this.showConfirmDelete = true;
@@ -484,12 +482,6 @@
         });
       },
 
-      async updateToken () {
-        if ( !auth.currentUser ) return;
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       mapReplayDoc ( doc ) {
         const data = doc.data();
         const streamer = data.user && data.user.name || data.name;
@@ -556,7 +548,6 @@
     async mounted () {
       console.log( 'StreamArchives loading...' );
       this.showDeletedArchives = this.channelOwner;
-      await this.updateToken();
       setTimeout( async () => await this.loadArchives(), 500 );
       try {
         this.$ga.event({

--- a/components/Chat/ChatAdminMenuButton/ManageChatConfig/ManageChatConfigContent.vue
+++ b/components/Chat/ChatAdminMenuButton/ManageChatConfig/ManageChatConfigContent.vue
@@ -153,14 +153,8 @@
     },
 
     methods: {
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async getConfig () {
         this.saving = true;
-        await this.getFreshIdToken();
 
         const endpoint = `https://api.bitwave.tv/v1/chat/config`;
 
@@ -191,7 +185,6 @@
 
       async updateConfig () {
         this.saving = true;
-        await this.getFreshIdToken();
 
         const endpoint = `https://api.bitwave.tv/v1/chat/config`;
         const payload = {

--- a/components/Chat/ChatAdminMenuButton/ViewMutedUsers/ViewMutedUsersContent.vue
+++ b/components/Chat/ChatAdminMenuButton/ViewMutedUsers/ViewMutedUsersContent.vue
@@ -101,14 +101,8 @@
     },
 
     methods: {
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async getBans () {
         this.loading = true;
-        await this.getFreshIdToken();
 
         const endpoint = `https://api.bitwave.tv/v1/chat/bans`;
 
@@ -129,8 +123,6 @@
 
       async unban ( user ) {
         user.loading = true;
-
-        await this.getFreshIdToken();
 
         const endpoint = `https://api.bitwave.tv/v1/chat/unban`;
         const payload = {

--- a/components/Chat/ChatMessages/ChatMessageMenu.vue
+++ b/components/Chat/ChatMessages/ChatMessageMenu.vue
@@ -189,14 +189,8 @@
         this.$emit( 'unignore', ( this.username || this.displayName ).toLowerCase() );
       },
 
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async getBans () {
         this.loading = true;
-        await this.getFreshIdToken();
 
         const endpoint = `https://api.bitwave.tv/v1/chat/bans`;
 
@@ -213,7 +207,6 @@
       },
 
       async banUser () {
-        await this.getFreshIdToken();
         const endpoint = `https://api.bitwave.tv/v1/chat/ban`;
         const payload =  {
           user: this.username,
@@ -235,7 +228,6 @@
       },
 
       async unbanUser () {
-        await this.getFreshIdToken();
         const endpoint = `https://api.bitwave.tv/v1/chat/unban`;
         const payload =  {
           user: this.username,

--- a/components/Restream/RestreamDialog.vue
+++ b/components/Restream/RestreamDialog.vue
@@ -359,15 +359,7 @@
         };
       },
 
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        console.log( `Fresh ID token:\n${token}` );
-        return token;
-      },
-
       async startRestreamer () {
-        const token = await this.getFreshIdToken();
-        this.$axios.setToken( token, 'Bearer' );
         const payload = this.createPayload();
         console.log(payload);
         try {
@@ -385,8 +377,6 @@
 
       async stopRestreamer () {
         try {
-          const token = await this.getFreshIdToken();
-          this.$axios.setToken( token, 'Bearer' );
           const payload = this.createPayload();
           const { data } = await this.$axios.post(
             this.createEndpoint( 'stop' ),

--- a/components/profile/ManageWebhooks.vue
+++ b/components/profile/ManageWebhooks.vue
@@ -64,11 +64,6 @@
     },
 
     methods: {
-      async getFreshIdToken () {
-        const token = await auth.currentUser.getIdToken( true );
-        this.$axios.setToken( token, 'Bearer' );
-      },
-
       async getWebhooks () {
         const result = await db
           .collection('webhooks')
@@ -117,7 +112,6 @@
 
       async testWebhooks () {
         this.testingWebhooks = true;
-        await this.getFreshIdToken();
         const endpoint = `https://api.bitwave.tv/v1/webhooks/test`;
         const payload = { user: this.username };
         try {

--- a/plugins/socket.io.js
+++ b/plugins/socket.io.js
@@ -1,4 +1,0 @@
-// import socketio from 'socket.io-client'
-// const socket = socketio('localhost:4000');
-
-// export default socket;

--- a/store/index.js
+++ b/store/index.js
@@ -1,5 +1,6 @@
 import { auth, db } from '@/plugins/firebase.js';
 import { Chat } from '@/store/chat';
+import { parseCookiesForAuth } from "~/assets/js/Cookies/parse";
 
 import * as utils from '@/plugins/store-utils.js';
 const logger = ( message, data ) => utils.logger( 'STORE', message, data );
@@ -305,28 +306,23 @@ export const mutations = {
 export const actions = {
 
   async nuxtServerInit ({ dispatch, commit }, { req, params, route }) {
-    let authUser = null;
-    // let user = null;
     const cookies = this.$cookies.getAll();
-    if ( cookies ) {
-      try {
-        if ( cookies.auth ) {
-          authUser = cookies.auth;
-          // commit( $mutations.setAuth, authUser );
-
-          logger( `[${route.path}] ${authUser.username} logged in via nuxtServerInit: `, params );
-        } else {
-          logger( `[${route.path}] User is not logged in.` );
-        }
-      } catch ( error ) {
-        logger( `Failed to get cookies!`, error );
+    try {
+      const authUser = parseCookiesForAuth( cookies );
+      if ( authUser ) {
+        // commit( $mutations.setAuth, authUser );
+        logger( `[${route.path}] ${authUser.username} logged in via nuxtServerInit: `, params );
+      } else {
+        logger( `[${route.path}] User is not logged in.` );
       }
+    } catch ( error ) {
+      logger( `Failed to get cookies!`, error );
+    }
 
-      // cookie for global chat hydration flag
-      const bwGlobal = cookies._bw_global;
-      if ( bwGlobal !== undefined ) {
-        commit( `${Chat.namespace}/${Chat.$mutations.setGlobalSSR}`, bwGlobal );
-      }
+    // cookie for global chat hydration flag
+    const bwGlobal = cookies._bw_global;
+    if ( bwGlobal !== undefined ) {
+      commit( `${Chat.namespace}/${Chat.$mutations.setGlobalSSR}`, bwGlobal );
     }
 
     const runParallel = [


### PR DESCRIPTION
Gone are the days of copy-pasted `getTokenId()` or `getFreshTokenId()` definitions and calls.

Surprisingly, all token usage was for request done through Axios. Axios requests are now intercepted and the Authorization header is being injected. The auth token is also automatically refreshed on client-side.

Server-side token parsing-from-cookies is also possible, but the commit-to-store part of it is commented out. Should only commit when on auth-guarded pages, or pages that make little sense to cache.

Closes #321