### PR TITLE
Add command handling for whispers v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwave.tv",
-  "version": "1.24.9",
+  "version": "1.24.10",
   "description": "An open platform live streaming service for creators to freely express themselves.",
   "author": "Dispatch",
   "scripts": {

--- a/store/chat.js
+++ b/store/chat.js
@@ -143,6 +143,8 @@ const $actions = {
   logout : 'LOGOUT',
 
   loadSettings : 'LOAD_SETTINGS',
+
+  sendWhisper : 'SEND_WHISPER',
 };
 
 
@@ -665,6 +667,37 @@ export const actions = {
     commit( Chat.$mutations.setIgnoreChannelList, oldIgnoreChannelList.map( i => i.toLowerCase() ) );
 
     loadFromLocalStorage( commit, settings );
+  },
+
+  async [$actions.sendWhisper] ( { state }, { receiver, message } ) {
+
+    const endpoint = 'https://api.bitwave.tv/v1/whispers/send';
+    const payload = {
+      chatToken: state[$states.chatToken],
+      receiver: receiver,
+      message: message,
+    };
+
+    try {
+      const { data } = await this.$axios.post( endpoint, payload, { progress: false, skipAuth: true } );
+      if ( !data ) {
+        console.error( `whisper: No response from server` );
+      }
+      else if ( data.success ) {
+        console.log( `Whisper Success` );
+      }
+      else if ( !data.success && data.message ) {
+        console.error( `Whisper Error: ${data.message}` );
+      }
+      else {
+        console.error( `Whisper Unknown Error` );
+      }
+      return data;
+    } catch ( error ) {
+      console.error( `Failed to send whisper`, error.message );
+      return null;
+    }
+
   },
 };
 


### PR DESCRIPTION
fixes #250

Just hooks up the chat store to the new API endpoint for whispers and adds some basic error handling.

the rest is handled server side between the API server and the chat server. At a later date will add support for viewing missed whispers.