### PR TITLE
Update nuxt.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,18 +23,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
-      "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.0",
+        "@babel/generator": "^7.11.6",
         "@babel/helper-module-transforms": "^7.11.0",
         "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.1",
+        "@babel/parser": "^7.11.5",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.11.0",
-        "@babel/types": "^7.11.0",
+        "@babel/traverse": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -56,11 +56,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-      "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
       "requires": {
-        "@babel/types": "^7.11.0",
+        "@babel/types": "^7.11.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -128,11 +128,10 @@
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
-      "integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
+      "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
       "requires": {
-        "@babel/traverse": "^7.10.4",
         "@babel/types": "^7.10.4"
       }
     },
@@ -214,14 +213,13 @@
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
-      "integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
+      "integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-wrap-function": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
         "@babel/types": "^7.10.4"
       }
     },
@@ -310,9 +308,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
-      "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA=="
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.10.5",
@@ -780,9 +778,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-      "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+      "integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4",
@@ -851,9 +849,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-      "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
+      "integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
       "requires": {
         "@babel/compat-data": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.10.4",
@@ -917,7 +915,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.10.4",
         "@babel/plugin-transform-unicode-regex": "^7.10.4",
         "@babel/preset-modules": "^0.1.3",
-        "@babel/types": "^7.11.0",
+        "@babel/types": "^7.11.5",
         "browserslist": "^4.12.0",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
@@ -926,9 +924,9 @@
       }
     },
     "@babel/preset-modules": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
-      "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+      "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
@@ -963,16 +961,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-      "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.0",
+        "@babel/generator": "^7.11.5",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.11.0",
-        "@babel/types": "^7.11.0",
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -989,9 +987,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-      "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.19",
@@ -1477,12 +1475,8 @@
       }
     },
     "@hcaptcha/vue-hcaptcha": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@hcaptcha/vue-hcaptcha/-/vue-hcaptcha-0.2.2.tgz",
-      "integrity": "sha512-kQmoMCtSLEhyGAjirLklpUD3/pSxcG+vw/Es2qQM+ID1fDmERGvNxonjBmZBnGv5hIpLEhMxHe2XL77EQxiq2Q==",
-      "requires": {
-        "vue": "2.6.11"
-      }
+      "version": "github:bitwave-tv/vue-hcaptcha#dfca6ed64ccb24144965b0dc8ee1446fdecab759",
+      "from": "github:bitwave-tv/vue-hcaptcha#dfca6ed64ccb24144965b0dc8ee1446fdecab759"
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -1508,11 +1502,11 @@
       }
     },
     "@nuxt/babel-preset-app": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/babel-preset-app/-/babel-preset-app-2.14.3.tgz",
-      "integrity": "sha512-GPodXma0jUQ8pViilV1R+C0X+TvjNZk2AFRKE8DxMw9WEC4WlS6QgUFTcPfN+GINtHtZTFCdwjB0BOR3iVi3kA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/babel-preset-app/-/babel-preset-app-2.14.4.tgz",
+      "integrity": "sha512-biQwzYGX4j/S6RKs1AZlIWFSeMTjTnnHJUnSSzYwqQLMraBdGcFbMlAzYdAa14gwCRAF3Dxu9WzTV/7h12iV/g==",
       "requires": {
-        "@babel/core": "^7.11.1",
+        "@babel/core": "^7.11.4",
         "@babel/helper-compilation-targets": "^7.10.4",
         "@babel/plugin-proposal-class-properties": "^7.10.4",
         "@babel/plugin-proposal-decorators": "^7.10.5",
@@ -1539,14 +1533,14 @@
       }
     },
     "@nuxt/builder": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/builder/-/builder-2.14.3.tgz",
-      "integrity": "sha512-aqeUwSuoPU1ZZVdoBr/FyPtiknCnxmC1K9MP66uKCVl1QJEcuOjhG92slUVSwDrHE09Q7Q5aEtKOP8tjQSzerw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/builder/-/builder-2.14.4.tgz",
+      "integrity": "sha512-87ecIi+YpTua8d0BqU1ZQUFNLskiR1x/79baTHxPosqH7qnltQor6LpivKlZOBv9yjEPoh4HVB2DGVBFm4wV2w==",
       "requires": {
         "@nuxt/devalue": "^1.2.4",
-        "@nuxt/utils": "2.14.3",
-        "@nuxt/vue-app": "2.14.3",
-        "@nuxt/webpack": "2.14.3",
+        "@nuxt/utils": "2.14.4",
+        "@nuxt/vue-app": "2.14.4",
+        "@nuxt/webpack": "2.14.4",
         "chalk": "^3.0.0",
         "chokidar": "^3.4.2",
         "consola": "^2.15.0",
@@ -1628,13 +1622,13 @@
       }
     },
     "@nuxt/cli": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-2.14.3.tgz",
-      "integrity": "sha512-bCRuADpkPKQE60kTuoZdKcXoY4vipveNqWDaUIfiyWEpl1/64T8j4XR1wyvCVgvdZvBctoRUWSdxMp0jT3PUPA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-2.14.4.tgz",
+      "integrity": "sha512-p2EOFCRtOC9b9tm15k5E+P68fx1gEAZQdKW2nItIv+Q4P2VTFwcKXoZOR9PzriJ3+Q5Kw5tNeaYXCsb51ZG5vg==",
       "requires": {
-        "@nuxt/config": "2.14.3",
+        "@nuxt/config": "2.14.4",
         "@nuxt/static": "^1.0.0",
-        "@nuxt/utils": "2.14.3",
+        "@nuxt/utils": "2.14.4",
         "boxen": "^4.2.0",
         "chalk": "^3.0.0",
         "compression": "^1.7.4",
@@ -1736,6 +1730,11 @@
           "requires": {
             "path-key": "^3.0.0"
           }
+        },
+        "opener": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
         },
         "p-finally": {
           "version": "2.0.1",
@@ -1884,9 +1883,9 @@
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -1902,11 +1901,11 @@
       }
     },
     "@nuxt/config": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/config/-/config-2.14.3.tgz",
-      "integrity": "sha512-EAFr69NvrWnKYVjIxRz0Z7uz1s5C/RaB62s2UE2CZs7bEiZfpXf5ZIFYJoaSnXSjdiOgS1/NdRYCT0idRVYs5w==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/config/-/config-2.14.4.tgz",
+      "integrity": "sha512-wHsyvQan2MCBnp55DUrYZtReNL8935pSQdc6RQxD3hOmU5hGV8B+sBILkPnSc2uGt7VG9bHVfcx1gTlxU/awMQ==",
       "requires": {
-        "@nuxt/utils": "2.14.3",
+        "@nuxt/utils": "2.14.4",
         "consola": "^2.15.0",
         "create-require": "^1.0.2",
         "defu": "^2.0.4",
@@ -1931,15 +1930,15 @@
       }
     },
     "@nuxt/core": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/core/-/core-2.14.3.tgz",
-      "integrity": "sha512-3PSIs6UhnnxEG2NqtFv9yVJZSiiJOMBAd4DdyUmKDw2EGbqvwNr6drgxvgFH1XI0jrxFlZQw14YLBfnDA8MXBQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/core/-/core-2.14.4.tgz",
+      "integrity": "sha512-PIBEN6fAZk7L3+OamydqPoregrip+XZmhG/LDYWThjtAbVZDasSwJ9/T8jD7J75qAxyM6q5Wd+uWOZ3D4X5giQ==",
       "requires": {
-        "@nuxt/config": "2.14.3",
+        "@nuxt/config": "2.14.4",
         "@nuxt/devalue": "^1.2.4",
-        "@nuxt/server": "2.14.3",
-        "@nuxt/utils": "2.14.3",
-        "@nuxt/vue-renderer": "2.14.3",
+        "@nuxt/server": "2.14.4",
+        "@nuxt/utils": "2.14.4",
+        "@nuxt/vue-renderer": "2.14.4",
         "consola": "^2.15.0",
         "debug": "^4.1.1",
         "esm": "^3.2.25",
@@ -2028,11 +2027,11 @@
       }
     },
     "@nuxt/generator": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/generator/-/generator-2.14.3.tgz",
-      "integrity": "sha512-rtDhrjaIuOb3X8RrOJt30c2EAlm2M3j5fLTc/11d3oCREn8Grdfz+XaKaV1PmlS8+7Jm3nG8rCGCb5pnXsUF/w==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/generator/-/generator-2.14.4.tgz",
+      "integrity": "sha512-CfFvvzlQNpkFmPO6MCVy1Up+Ha3/scoWwIl9hHcN7WvlHVzlyK/5AOJTKW3xgeWcCFA+se5iTgK2K/5w/cWFGQ==",
       "requires": {
-        "@nuxt/utils": "2.14.3",
+        "@nuxt/utils": "2.14.4",
         "chalk": "^3.0.0",
         "consola": "^2.15.0",
         "fs-extra": "^8.1.0",
@@ -2089,13 +2088,13 @@
       }
     },
     "@nuxt/server": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/server/-/server-2.14.3.tgz",
-      "integrity": "sha512-Tt1u7eMDqL/27ErsrbLeu1j7ZdJBBBP1sjpnlBWRrM9BtqLULiwHmCAxvMgSB6LX1784TiX5PtQBdQfML53HGg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/server/-/server-2.14.4.tgz",
+      "integrity": "sha512-HRTZBgJWLgphaSnyhUTr9W9SxVaf0a/j9MuXVniuLlVI7aHqCKvWkYCj2pnPzhTKdf3qVRDkIQuI6g8TOZDHVQ==",
       "requires": {
-        "@nuxt/config": "2.14.3",
-        "@nuxt/utils": "2.14.3",
-        "@nuxt/vue-renderer": "2.14.3",
+        "@nuxt/config": "2.14.4",
+        "@nuxt/utils": "2.14.4",
+        "@nuxt/vue-renderer": "2.14.4",
         "@nuxtjs/youch": "^4.2.3",
         "chalk": "^3.0.0",
         "compression": "^1.7.4",
@@ -2186,9 +2185,9 @@
       }
     },
     "@nuxt/utils": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/utils/-/utils-2.14.3.tgz",
-      "integrity": "sha512-a5TfeLdGEX5NPR8Vc0Zqi3DRr5SmIwuczKD5r80825NZ2A1PGexUNJa9/vUnOLxXfGLrv561tJN11sx9AxihOA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/utils/-/utils-2.14.4.tgz",
+      "integrity": "sha512-NSKZ1idNoHswYUSC7sz9pfZ6pWU+3n7emBrkiw7hCaULWSYwv+TqkkNPtTWt/6Uwdc+8Y8C/SnKF1wNhtBxdBA==",
       "requires": {
         "consola": "^2.15.0",
         "fs-extra": "^8.1.0",
@@ -2218,34 +2217,34 @@
       }
     },
     "@nuxt/vue-app": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/vue-app/-/vue-app-2.14.3.tgz",
-      "integrity": "sha512-cS6f2Uu0EYjc9PWjTFSSie1Ts+H+cZBTOWkcb8mjPlkYxb0rU29mKFLXt1JpzadpA5s/iQJ6jKBp3zZCZRHDqg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/vue-app/-/vue-app-2.14.4.tgz",
+      "integrity": "sha512-67jxuW69j/Gtf4q7FH8i4q1glTujU/WqjjdyE97ClFWT6wMU3VivxrH4q4B8MC61WiVn5SAG04xnc2vAh7znaw==",
       "requires": {
         "node-fetch": "^2.6.0",
         "unfetch": "^4.1.0",
-        "vue": "^2.6.11",
+        "vue": "^2.6.12",
         "vue-client-only": "^2.0.0",
         "vue-meta": "^2.4.0",
         "vue-no-ssr": "^1.1.1",
         "vue-router": "^3.4.3",
-        "vue-template-compiler": "^2.6.11",
+        "vue-template-compiler": "^2.6.12",
         "vuex": "^3.5.1"
       }
     },
     "@nuxt/vue-renderer": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/vue-renderer/-/vue-renderer-2.14.3.tgz",
-      "integrity": "sha512-o5JmRRrhdnBtejqzJTm/fTC3mTUAAi+eH7RO+1AJVarWNEN2DdZr3Y3jS141PCLZrcpxgdAjw4v4zzMVYjz56g==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/vue-renderer/-/vue-renderer-2.14.4.tgz",
+      "integrity": "sha512-bYCj0RVpNcpXLw0XbyuGoCJcfCoNbAAHzTvmY5r1hbeGyvZ8IDd34/PeFoPwLX/KwqdZCIZdVFlF3z/JBlJ/zw==",
       "requires": {
         "@nuxt/devalue": "^1.2.4",
-        "@nuxt/utils": "2.14.3",
+        "@nuxt/utils": "2.14.4",
         "consola": "^2.15.0",
         "fs-extra": "^8.1.0",
         "lru-cache": "^5.1.1",
-        "vue": "^2.6.11",
+        "vue": "^2.6.12",
         "vue-meta": "^2.4.0",
-        "vue-server-renderer": "^2.6.11"
+        "vue-server-renderer": "^2.6.12"
       },
       "dependencies": {
         "consola": {
@@ -2256,17 +2255,17 @@
       }
     },
     "@nuxt/webpack": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/webpack/-/webpack-2.14.3.tgz",
-      "integrity": "sha512-iLLyTER4asYjXP4vkfpWCLtUzZ+bRCQua85musNCn7HuDnmc3nuQ3Fni2R8obUyKzNpNJG2Ucer12o2yQYr+jA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/webpack/-/webpack-2.14.4.tgz",
+      "integrity": "sha512-91qcNMWfX0nWp+5bprvmUjDdvlXtv7VjbBYXkHZZ+1Het5d90VAwqSLVKHpBCWqf0QG0ZNmz0hkCnJbduxk7Kw==",
       "requires": {
-        "@babel/core": "^7.11.1",
-        "@nuxt/babel-preset-app": "2.14.3",
+        "@babel/core": "^7.11.4",
+        "@nuxt/babel-preset-app": "2.14.4",
         "@nuxt/friendly-errors-webpack-plugin": "^2.5.0",
-        "@nuxt/utils": "2.14.3",
+        "@nuxt/utils": "2.14.4",
         "babel-loader": "^8.1.0",
         "cache-loader": "^4.1.0",
-        "caniuse-lite": "^1.0.30001114",
+        "caniuse-lite": "^1.0.30001118",
         "chalk": "^3.0.0",
         "consola": "^2.15.0",
         "create-require": "^1.0.2",
@@ -2300,7 +2299,7 @@
         "webpack-bundle-analyzer": "^3.8.0",
         "webpack-dev-middleware": "^3.7.2",
         "webpack-hot-middleware": "^2.25.0",
-        "webpack-node-externals": "^2.5.1",
+        "webpack-node-externals": "^2.5.2",
         "webpackbar": "^4.0.0"
       },
       "dependencies": {
@@ -2859,9 +2858,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.41.21",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
-      "integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+      "version": "4.41.22",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
+      "integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
       "requires": {
         "@types/anymatch": "*",
         "@types/node": "*",
@@ -3389,9 +3388,9 @@
       }
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -3912,15 +3911,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "blob": {
       "version": "0.0.5",
@@ -4464,9 +4454,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001114",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001114.tgz",
-      "integrity": "sha512-ml/zTsfNBM+T1+mjglWRPgVsu2L76GAaADKX5f4t0pbhttEp0WMawJsHDYlFkVZkoA+89uvBRrVrEE4oqenzXQ=="
+      "version": "1.0.30001124",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
+      "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA=="
     },
     "card-validator": {
       "version": "6.2.0",
@@ -5479,6 +5469,11 @@
             "uri-js": "^4.2.2"
           }
         },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -5490,13 +5485,13 @@
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
           "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
           }
         },
         "semver": {
@@ -6059,9 +6054,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.533",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.533.tgz",
-      "integrity": "sha512-YqAL+NXOzjBnpY+dcOKDlZybJDCOzgsq4koW3fvyty/ldTmsb4QazZpOWmVvZ2m0t5jbBf7L0lIGU3BUipwG+A=="
+      "version": "1.3.562",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz",
+      "integrity": "sha512-WhRe6liQ2q/w1MZc8mD8INkenHivuHdrr4r5EQHNomy3NJux+incP6M6lDMd0paShP3MD0WGe5R1TWmEClf+Bg=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -6403,11 +6398,18 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+        }
       }
     },
     "estraverse": {
@@ -6827,12 +6829,6 @@
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.5.0"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "filesize": {
       "version": "3.6.1",
@@ -7289,9 +7285,9 @@
       }
     },
     "git-url-parse": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.3.tgz",
-      "integrity": "sha512-GPsfwticcu52WQ+eHp0IYkAyaOASgYdtsQDIt4rUp6GbiNt1P9ddrh3O0kQB0eD4UJZszVqNT3+9Zwcg40fywA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.2.0.tgz",
+      "integrity": "sha512-KPoHZg8v+plarZvto4ruIzzJLFQoRx+sUs5DQSr07By9IBKguVd+e6jwrFR6/TP6xrCJlNV1tPqLO1aREc7O2g==",
       "requires": {
         "git-up": "^4.0.0"
       }
@@ -7986,9 +7982,9 @@
       "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
     },
     "html-webpack-plugin": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.3.0.tgz",
-      "integrity": "sha512-C0fzKN8yQoVLTelcJxZfJCE+aAvQiY2VUf3UuKrR4a9k5UMWYOtpDLsaXwATbcVCnI05hUS7L9ULQHWLZhyi3w==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.4.1.tgz",
+      "integrity": "sha512-nEtdEIsIGXdXGG7MjTTZlmhqhpHU9pJFc1OYxcP36c5/ZKP6b0BJMww2QTvJGQYA9aMxUnjDujpZdYcVOXiBCQ==",
       "requires": {
         "@types/html-minifier-terser": "^5.0.0",
         "@types/tapable": "^1.0.5",
@@ -8382,9 +8378,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -8794,9 +8790,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -9304,9 +9300,9 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.0.tgz",
-      "integrity": "sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.1.tgz",
+      "integrity": "sha512-Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==",
       "requires": {
         "map-age-cleaner": "^0.1.3",
         "mimic-fn": "^3.0.0"
@@ -10033,20 +10029,20 @@
       "dev": true
     },
     "nuxt": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-2.14.3.tgz",
-      "integrity": "sha512-7f5adPiIkZvv5Fu7tKhHuKdMv4IvSbBC1sbuBcgjtRedu4rP/tQPL4/8PZcEUieolcfwaN+WGPNz3sMGyPTLzg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-2.14.4.tgz",
+      "integrity": "sha512-s6+VePRUBjOU2huJaevE3M19qOblXm9n7BtSxeWEFbDPomOOtdQqUVKbFJrtjgGPETpDrZ6FUKI94/0rkPwNcg==",
       "requires": {
-        "@nuxt/builder": "2.14.3",
-        "@nuxt/cli": "2.14.3",
+        "@nuxt/builder": "2.14.4",
+        "@nuxt/cli": "2.14.4",
         "@nuxt/components": "^1.1.0",
-        "@nuxt/core": "2.14.3",
-        "@nuxt/generator": "2.14.3",
+        "@nuxt/core": "2.14.4",
+        "@nuxt/generator": "2.14.4",
         "@nuxt/loading-screen": "^2.0.2",
         "@nuxt/opencollective": "^0.3.0",
         "@nuxt/static": "^1.0.0",
         "@nuxt/telemetry": "^1.2.3",
-        "@nuxt/webpack": "2.14.3"
+        "@nuxt/webpack": "2.14.4"
       }
     },
     "nuxt-stripe-module": {
@@ -10200,14 +10196,14 @@
       }
     },
     "opener": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A=="
     },
     "optimize-css-assets-webpack-plugin": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
-      "integrity": "sha512-q9fbvCRS6EYtUKKSwI87qm2IxlyJK5b4dygW1rKUBT6mMDhdG5e5bZT63v6tnJR9F9FB/H5a0HTmtw+laUBxKA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz",
+      "integrity": "sha512-wqd6FdI2a5/FdoiCNNkEvLeA//lHHfG24Ln2Xm2qqdIk4aOlsR18jwpyOihqQ8849W3qu2DX8fOYxpvTMj+93A==",
       "requires": {
         "cssnano": "^4.1.10",
         "last-call-webpack-plugin": "^3.0.0"
@@ -10628,9 +10624,9 @@
       }
     },
     "postcss-calc": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.3.tgz",
-      "integrity": "sha512-IB/EAEmZhIMEIhG7Ov4x+l47UaXOS1n2f4FBUk/aKllQhtSCxWhTzn0nJgkqN7fo/jcWySvWTSB6Syk9L+31bA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.4.tgz",
+      "integrity": "sha512-0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==",
       "requires": {
         "postcss": "^7.0.27",
         "postcss-selector-parser": "^6.0.2",
@@ -11534,9 +11530,9 @@
       "optional": true
     },
     "pretty-bytes": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
+      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA=="
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -13627,6 +13623,11 @@
             "uri-js": "^4.2.2"
           }
         },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+        },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -13689,13 +13690,13 @@
           }
         },
         "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
           "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
           }
         },
         "semver": {
@@ -13980,9 +13981,9 @@
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "uglify-js": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
-      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q=="
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.3.tgz",
+      "integrity": "sha512-Lh00i69Uf6G74mvYpHCI9KVVXLcHW/xu79YTvH7Mkc9zyKUeSPz0owW0dguj0Scavns3ZOh3wY63J0Zb97Za2g=="
     },
     "ultron": {
       "version": "1.0.2",
@@ -14411,9 +14412,9 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "vue": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
-      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
+      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
     },
     "vue-analytics": {
       "version": "5.22.1",
@@ -14482,9 +14483,9 @@
       "integrity": "sha512-BADg1mjGWX18Dpmy6bOGzGNnk7B/ZA0RxuA6qedY/YJwirMfKXIDzcccmHbQI0A6k5PzMdMloc0ElHfyOoX35A=="
     },
     "vue-server-renderer": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.11.tgz",
-      "integrity": "sha512-V3faFJHr2KYfdSIalL+JjinZSHYUhlrvJ9pzCIjjwSh77+pkrsXpK4PucdPcng57+N77pd1LrKqwbqjQdktU1A==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.12.tgz",
+      "integrity": "sha512-3LODaOsnQx7iMFTBLjki8xSyOxhCtbZ+nQie0wWY4iOVeEtTg1a3YQAjd82WvKxrWHHTshjvLb7OXMc2/dYuxw==",
       "requires": {
         "chalk": "^1.1.3",
         "hash-sum": "^1.0.2",
@@ -14492,7 +14493,7 @@
         "lodash.template": "^4.5.0",
         "lodash.uniq": "^4.5.0",
         "resolve": "^1.2.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^3.1.0",
         "source-map": "0.5.6"
       },
       "dependencies": {
@@ -14514,9 +14515,12 @@
           }
         },
         "serialize-javascript": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+          "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
         },
         "source-map": {
           "version": "0.5.6",
@@ -14540,9 +14544,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
-      "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
+      "integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
       "requires": {
         "de-indent": "^1.0.2",
         "he": "^1.1.0"
@@ -14702,7 +14706,6 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -14957,9 +14960,9 @@
       }
     },
     "webpack-node-externals": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-2.5.1.tgz",
-      "integrity": "sha512-RWxKGibUU5kuJT6JDYmXGa3QsZskqIaiBvZ2wBxHlJzWVJPOyBMnroXf23uxEHnj1rYS8jNdyUfrNAXJ2bANNw=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-2.5.2.tgz",
+      "integrity": "sha512-aHdl/y2N7PW2Sx7K+r3AxpJO+aDMcYzMQd60Qxefq3+EwhewSbTBqNumOsCE1JsCUNoyfGj5465N0sSf6hc/5w=="
     },
     "webpack-sources": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@bitwave/chat-client": "^0.3.8",
-    "@hcaptcha/vue-hcaptcha": "^0.2.2",
+    "@hcaptcha/vue-hcaptcha": "github:bitwave-tv/vue-hcaptcha#dfca6ed64ccb24144965b0dc8ee1446fdecab759",
     "@nuxtjs/axios": "^5.12.2",
     "@nuxtjs/component-cache": "^1.1.6",
     "@nuxtjs/device": "^1.2.7",
@@ -43,7 +43,7 @@
     "jwt-decode": "^2.2.0",
     "marked": "^0.7.0",
     "moment": "^2.27.0",
-    "nuxt": "^2.14.3",
+    "nuxt": "^2.14.4",
     "nuxt-stripe-module": "^2.1.0",
     "sass-loader": "^10.0.2",
     "socket.io-client": "^2.3.0",


### PR DESCRIPTION
Updates to latest version of nuxt.js by using a patched fork of vue-hcpatcha that does not include the vue.js versioning conflict.